### PR TITLE
409 show error messages from making a person record from a census record

### DIFF
--- a/app/controllers/census_records/main_controller.rb
+++ b/app/controllers/census_records/main_controller.rb
@@ -170,7 +170,9 @@ module CensusRecords
       if person.persisted?
         flash[:notice] = "A new person record has been created from this census record."
       else
-        flash[:error] = "Unable to create a person record from this census record."
+        error_message = "Unable to create a person record from this census record. "
+        error_message += person.errors.full_messages.to_sentence if person.errors.any?
+        flash[:error] = error_message
       end
       redirect_back fallback_location: { action: :index }
     end


### PR DESCRIPTION
Sometimes "Create Person Record" fails. Let's show a nice error message, along with the full error messages from the person record. That will guide the user about what they need to fix.

Closes issue #409.