### PR TITLE
413 Person record relatives ordering and showing the data for that census year

### DIFF
--- a/app/views/people/main/show.html.slim
+++ b/app/views/people/main/show.html.slim
@@ -100,7 +100,7 @@
               - census_record = census_record.decorate
               tr
                 td.text-nowrap
-                  = link_to census_record.name, census_record.person
+                  = link_to census_record.name, person_path(census_record.person_id)
                 td= census_record.relation_to_head
                 td.text-nowrap= census_record.street_address
                 td= census_record.age

--- a/app/views/people/main/show.html.slim
+++ b/app/views/people/main/show.html.slim
@@ -44,33 +44,34 @@
       = auto_link(simple_format(@person.description), html: { target: '_blank', rel: 'nofollow' })
 .card.mb-3
   .card-header Census Records
-  = table do
-    thead
-      tr
-        th Year
-        th Name
-        th
-          | Relation
-          span.d-none.d-lg-inline &nbsp;to Head
-        th Address
-        th Age
-        th Race
-        th POB
-        th Marriage
-        th Occupation
-    tbody
-      - @person.census_records.each do |raw_row|
-        - row = raw_row.decorate
+  .table-responsive
+    table.table.table-sm.w-100
+      thead
         tr
-          td= row.year
-          td.text-nowrap= link_to row.name, row
-          td= row.relation_to_head if row.year >= 1880
-          td.text-nowrap= row.street_address
-          td= row.age
-          td= row.race
-          td= row.pob
-          td= row.marital_status
-          td= row.occupation
+          th Year
+          th Name
+          th
+            | Relation
+            span.d-none.d-lg-inline &nbsp;to Head
+          th Address
+          th Age
+          th Race
+          th POB
+          th Marriage
+          th Occupation
+      tbody
+        - @person.census_records.each do |raw_row|
+          - row = raw_row.decorate
+          tr
+            td= row.year
+            td.text-nowrap= link_to row.name, row
+            td= row.relation_to_head if row.year >= 1880
+            td.text-nowrap= row.street_address
+            td= row.age
+            td= row.race
+            td= row.pob
+            td= row.marital_status
+            td= row.occupation
 
 - if @person.relatives.present?
   - all_years = @person.relatives.flat_map { |r| r.census_records.map(&:year) }.uniq.sort
@@ -78,26 +79,35 @@
     .card.mb-3
       .card-header
         | Relatives in #{year} US Census
-      = table do
-        thead
-          tr
-            th Name
-            th
-              | Relation
-              span.d-none.d-lg-inline &nbsp;to Head
-            th Race
-            th Sex
-            th YOB
-            th Occupation
-        tbody
-          - @person.relatives.select { |r| r.census_records.map(&:year).include?(year) }.map(&:decorate).each do |row|
+      .table-responsive
+        table.table.table-sm.w-100
+          thead
             tr
-              td.text-nowrap= link_to row.name, row
-              td= row.relation_to_head
-              td= "#{Translator.option(:race, row.race)} " if row.race.present? && row.race != 'on'
-              td= "#{Translator.option(:sex, row.sex)} " if row.sex.present? && row.sex != 'on'
-              td= row.birth_year
-              td= row.occupation
+              th Name
+              th
+                | Relation
+                span.d-none.d-lg-inline &nbsp;to Head
+              th Address
+              th Age
+              th Race
+              th POB
+              th Marriage
+              th Occupation
+          tbody
+            - relatives_in_year = @person.relatives.select { |r| r.census_records.map(&:year).include?(year) }
+            - census_records = relatives_in_year.map { |relative| relative.census_records.find { |r| r.year == year } }
+            - census_records.sort_by { |r| [r.page_number.to_i, r.page_side.to_s, r.line_number.to_i] }.each do |census_record|
+              - census_record = census_record.decorate
+              tr
+                td.text-nowrap
+                  = link_to census_record.name, census_record.person
+                td= census_record.relation_to_head
+                td.text-nowrap= census_record.street_address
+                td= census_record.age
+                td= census_record.race
+                td= census_record.pob
+                td= census_record.marital_status
+                td= census_record.occupation
 
 
 - if can?(:update, @person) && @person.possible_unmatched_records.present?


### PR DESCRIPTION
Person record relatives list is slowing evolving away from list of person records to lists of census records. Here is another waypoint on that journey. Now the lists are sorted in census order, and show the data from the census record, even though the link is still to the person record.