### PR TITLE
319 add sortble matched name order

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -22,11 +22,12 @@ class PersonSearch < SearchQueryBuilder
   def results
     scoped.to_a.map(&:decorate)
   end
+
   memoize :results
 
   def scoped
     builder.preload(:names)
-    builder.group('people.id')
+    builder.group("people.id")
     builder.offset(from) if from
     builder.limit(to.to_i - from.to_i) if from && to
     builder.uncensused if uncensused?
@@ -34,17 +35,18 @@ class PersonSearch < SearchQueryBuilder
     add_census_record_links
     add_see_names
     add_sorts
-    scope_to_locality if Current.locality_id && !s.key?('localities_id_in')
-    builder.preload(:localities) if f.include?('locality_ids')
+    scope_to_locality if Current.locality_id && !s.key?("localities_id_in")
+    builder.preload(:localities) if f.include?("locality_ids")
     builder.scoped.distinct
   end
+
   memoize :scoped
 
   def count
     builder.uncensused if uncensused?
     builder.photographed if photographed?
-    scope_to_locality if Current.locality_id && !s.key?('localities_id_in')
-    entity_class.where(id: builder.scoped.select('people.id')).count
+    scope_to_locality if Current.locality_id && !s.key?("localities_id_in")
+    entity_class.where(id: builder.scoped.select("people.id")).count
   end
 
   def scope_to_locality
@@ -53,7 +55,7 @@ class PersonSearch < SearchQueryBuilder
   end
 
   def add_census_record_links
-    builder.select 'people.*'
+    builder.select "people.*"
     CensusYears.each do |year|
       next unless f.include?("census#{year}")
 
@@ -65,25 +67,25 @@ class PersonSearch < SearchQueryBuilder
   def add_see_names
     return unless has_names_joined?
 
-    builder.group('person_names.id')
-    builder.select(builder.scoped.select_values, 'person_names.first_name as matched_first_name, person_names.last_name as matched_last_name, concat_ws(\' \', lower(person_names.last_name), lower(person_names.first_name)) as sortable_matched_name')
+    builder.group("person_names.id")
+    builder.select(builder.scoped.select_values, 'person_names.first_name as matched_first_name, person_names.last_name as matched_last_name, concat_ws(\', \', lower(person_names.last_name), lower(person_names.first_name)) as sortable_matched_name')
   end
 
   def add_sorts
     order = []
     sort&.each_value do |sort_unit|
-      col = sort_unit['colId']
-      dir = sort_unit['sort']
-      next if col == 'locality_ids'
+      col = sort_unit["colId"]
+      dir = sort_unit["sort"]
+      next if col == "locality_ids"
 
-      order << if col == 'name'
-                 name_order_clause(dir)
-               else
-                 "#{col} #{dir}"
-               end
+      order << if col == "name"
+        name_order_clause(dir)
+      else
+        "#{col} #{dir}"
+      end
     end
-    order << name_order_clause('ASC') if sort.blank?
-    builder.order(entity_class.sanitize_sql_for_order(order.join(', '))) if order
+    order << name_order_clause("ASC") if sort.blank?
+    builder.order(entity_class.sanitize_sql_for_order(order.join(", "))) if order
   end
 
   def name_order_clause(dir)
@@ -99,15 +101,15 @@ class PersonSearch < SearchQueryBuilder
   end
 
   def all_fields
-    default_fields + %w[locality_ids description] + CensusYears.map { |year| "census#{year}"}
+    default_fields + %w[locality_ids description] + CensusYears.map { |year| "census#{year}" }
   end
 
   def uncensused?
-    @scope == 'uncensused'
+    @scope == "uncensused"
   end
 
   def photographed?
-    @scope == 'photographed'
+    @scope == "photographed"
   end
 
   def has_names_joined?

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails'
+require "rails"
 # Pick the frameworks you want:
-require 'active_model/railtie'
-require 'active_job/railtie'
-require 'active_record/railtie'
-require 'active_storage/engine'
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
 # require 'action_mailbox/engine'
-require 'action_text/engine'
-require 'action_view/railtie'
+require "action_text/engine"
+require "action_view/railtie"
 # require "action_cable/engine"
 # require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-require 'csv'
+require "csv"
 
-unless ENV['DATABASE_URL']
-  require 'dotenv'
-  Dotenv.load('.env', ".env.#{Rails.env}")
+unless ENV["DATABASE_URL"]
+  require "dotenv"
+  Dotenv.load(".env", ".env.#{Rails.env}")
 end
-
 
 module HistoryForge
   class Application < Rails::Application
@@ -40,7 +39,7 @@ module HistoryForge
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.action_mailer.default_url_options = { host: ENV['BASE_URL'] }
+    config.action_mailer.default_url_options = { host: ENV["BASE_URL"] }
 
     config.quiet_assets = true
 
@@ -49,5 +48,6 @@ module HistoryForge
 
     config.generators.test_framework :rspec
     config.active_record.schema_format = :sql
+    config.active_record.migration_error = :page_load
   end
 end

--- a/spec/services/people/likely_matches_spec.rb
+++ b/spec/services/people/likely_matches_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 module People
   RSpec.describe LikelyMatches do
     subject { outcome[:matches].first }
     let(:outcome) { described_class.run!(record:) }
-    let(:record) { FactoryBot.create(:census1910_record, first_name: 'David', last_name: 'Furber', sex: 'm', race: 'w') }
-    let(:non_matching_person) { FactoryBot.create(:person, first_name: 'Michael', last_name: 'Furber', sex: 'm', race: 'W') }
+    let(:record) { FactoryBot.create(:census1910_record, first_name: "David", last_name: "Furber", sex: "m", race: "W") }
+    let(:non_matching_person) { FactoryBot.create(:person, first_name: "Michael", last_name: "Furber", sex: "m", race: "W") }
 
     before do
+      Census1910Record.where(first_name: "David", last_name: "Furber", sex: "m", race: "W").delete_all
       # Automatic matching only engages when there is more than one census going.
       # Otherwise, partners get confused by "mystery matches" when logically
       # there shouldn't be an existing person record for anyone yet. That's why
@@ -19,26 +20,26 @@ module People
       non_matching_person
     end
 
-    context 'when there is an exact match' do
-      let(:matching_person) { FactoryBot.create(:person, first_name: 'David', last_name: 'Furber', sex: 'm', race: 'W') }
+    context "when there is an exact match" do
+      let(:matching_person) { FactoryBot.create(:person, first_name: "David", last_name: "Furber", sex: "m", race: "W") }
 
       it { is_expected.to eq(matching_person) }
     end
 
-    context 'when there is a same last name and cognate first name match' do
-      let!(:matching_person) { FactoryBot.create(:person, first_name: 'Dave', last_name: 'Furber', sex: 'm', race: 'W') }
+    context "when there is a same last name and cognate first name match" do
+      let!(:matching_person) { FactoryBot.create(:person, first_name: "Dave", last_name: "Furber", sex: "m", race: "W") }
 
       it { is_expected.to eq(matching_person) }
     end
 
-    context 'when there is a same last name and cognate middle name match' do
-      let!(:matching_person) { FactoryBot.create(:person, first_name: 'B', middle_name: 'Dave', last_name: 'Furber', sex: 'm', race: 'W') }
+    context "when there is a same last name and cognate middle name match" do
+      let!(:matching_person) { FactoryBot.create(:person, first_name: "B", middle_name: "Dave", last_name: "Furber", sex: "m", race: "W") }
 
       it { is_expected.to eq(matching_person) }
     end
 
-    context 'when there is a similar last name and cognate first name match' do
-      let!(:matching_person) { FactoryBot.create(:person, first_name: 'Dave', last_name: 'Ferber', sex: 'm', race: 'W') }
+    context "when there is a similar last name and cognate first name match" do
+      let!(:matching_person) { FactoryBot.create(:person, first_name: "Dave", last_name: "Ferber", sex: "m", race: "W") }
 
       it { is_expected.to eq(matching_person) }
     end


### PR DESCRIPTION
Closes #319 because it adds a comma to the separator for sortable matched names. On the tompkins server PG version, it ignores the space in concat_ws, adding a comma should help it.