### PR TITLE
[426] civil war column length issue

### DIFF
--- a/app/models/census1910_record.rb
+++ b/app/models/census1910_record.rb
@@ -93,7 +93,6 @@
 
 # Model class for 1910 US Census records.
 class Census1910Record < CensusRecord
-
   self.table_name = 'census_1910_records'
   self.year = 1910
 

--- a/app/models/census_record.rb
+++ b/app/models/census_record.rb
@@ -10,6 +10,8 @@ class CensusRecord < ApplicationRecord
   include Flaggable
   include Versioning
 
+  self.ignored_columns += %i[ward_str enum_dist_str]
+
   belongs_to :building, optional: true
   belongs_to :person, optional: true
   has_many :bulk_updated_records, as: :record, dependent: :destroy, inverse_of: :record

--- a/app/models/census_record.rb
+++ b/app/models/census_record.rb
@@ -3,14 +3,14 @@
 # Base class for census records.
 class CensusRecord < ApplicationRecord
   self.abstract_class = true
+  self.ignored_columns += %i[ward_str enum_dist_str]
+
   include CensusRecords::Searchable
   include CensusRecords::Addressable
   include Moderation
   include PersonNames
   include Flaggable
   include Versioning
-
-  self.ignored_columns += %i[ward_str enum_dist_str]
 
   belongs_to :building, optional: true
   belongs_to :person, optional: true

--- a/app/models/concerns/census_records/addressable.rb
+++ b/app/models/concerns/census_records/addressable.rb
@@ -26,12 +26,6 @@ module CensusRecords
        apartment_number ? "Apt. #{apartment_number}" : nil].compact.join(' ')
     end
 
-    def latitude
-      building&.lat
-    end
-
-    def longitude
-      building&.lon
-    end
+    delegate :latitude, :longitude, to: :building, allow_nil: true
   end
 end

--- a/db/migrate/20250709201454_civil_war_column_length.rb
+++ b/db/migrate/20250709201454_civil_war_column_length.rb
@@ -1,0 +1,5 @@
+class CivilWarColumnLength < ActiveRecord::Migration[7.2]
+  def change
+    change_column :census_1910_records, :civil_war_vet, :string, limit: 10
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,7 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
---SET transaction_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -1114,7 +1114,7 @@ CREATE TABLE public.census_1910_records (
     blind boolean DEFAULT false,
     deaf_dumb boolean DEFAULT false,
     notes text,
-    civil_war_vet character varying(2),
+    civil_war_vet character varying(10),
     provisional boolean DEFAULT false,
     foreign_born boolean DEFAULT false,
     taker_error boolean DEFAULT false,
@@ -5613,6 +5613,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('9'),
 ('8'),
 ('4'),
+('20250709201454'),
 ('20250325233212'),
 ('20250325015620'),
 ('20250302232511'),


### PR DESCRIPTION
1910 census records is a 2 character string. That works for all values except "unknown". We can't let it use "un" because that means "Union Navy". We need to let it specify "unknown". Increase the column length to 10.