### PR TITLE
[415] ignore recaptcha when the configs are not set up

### DIFF
--- a/app/controllers/concerns/recaptcha_handlers.rb
+++ b/app/controllers/concerns/recaptcha_handlers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RecaptchaHandlers
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :lazy_configure_recaptcha, if: :using_recaptcha?
+    before_action :check_captcha, only: :create, if: :using_recaptcha?
+  end
+
+  private
+
+  def check_captcha
+    return if verify_recaptcha(action: 'contact', minimum_score: 0.5, secret_key: AppConfig[:recaptcha_secret_key])
+
+    flash[:error] = 'Oops did you fill out the form correctly?'
+    render action: :new
+  end
+
+  def using_recaptcha?
+    AppConfig[:recaptcha_site_key].present? && AppConfig[:recaptcha_secret_key].present?
+  end
+
+  def lazy_configure_recaptcha
+    Recaptcha.configure do |config|
+      config.site_key = AppConfig[:recaptcha_site_key]
+      config.secret_key = AppConfig[:recaptcha_secret_key]
+    end
+  end
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ContactsController < ApplicationController
-  before_action :lazy_configure_recaptcha
+  include RecaptchaHandlers
 
   def new
     @contact = Contact.new
@@ -16,13 +16,6 @@ class ContactsController < ApplicationController
     else
       flash[:error] = 'Oops did you fill out the form correctly?'
       render action: :new
-    end
-  end
-
-  def lazy_configure_recaptcha
-    Recaptcha.configure do |config|
-      config.site_key = AppConfig[:recaptcha_site_key]
-      config.secret_key = AppConfig[:recaptcha_secret_key]
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,8 +2,7 @@
 
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    prepend_before_action :check_captcha, only: :create
-    prepend_before_action :lazy_configure_recaptcha
+    include RecaptchaHandlers
 
     # GET /resource/sign_up
     # def new
@@ -62,14 +61,6 @@ module Users
 
     def sign_up_params
       params.require(:user).permit(:login, :email, :password, :password_confirmation)
-    end
-
-    def lazy_configure_recaptcha
-      Recaptcha.configure do |config|
-        config.site_key = AppConfig[:recaptcha_site_key]
-        config.secret_key = AppConfig[:recaptcha_secret_key]
-        config.skip_verify_env = %w[test]
-      end
     end
 
     def check_captcha


### PR DESCRIPTION
Closes #415.

A new install may not have Recaptcha set up. While they will soon find out why they should set it up, let's not make it an obstacle to get started. At the points where we use Recaptcha, let's ignore it if they haven't set the app configs.