### PR TITLE
[436] allow editing of person record with unenumerated race

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,39 +41,41 @@ class Person < ApplicationRecord
 
   NAME_VARIANT_ATTRIBUTES = %w[first_name last_name].freeze
   PRIMARY_NAME_ATTRIBUTES = %w[name_prefix first_name middle_name last_name name_suffix].freeze
+  SEXES = %w[M F].freeze
+  RACES = %w[W B Mu Mex In Ch Jp Fil Hin Kor].freeze
 
   attr_accessor :match_score
 
-  define_enumeration :sex, %w[M F].freeze
-  define_enumeration :race, %w[W B Mu Mex In Ch Jp Fil Hin Kor].freeze
+  define_enumeration :sex, SEXES
+  define_enumeration :race, RACES
 
-  has_many :census1850_records, dependent: :nullify, class_name: "Census1850Record", inverse_of: :person
-  has_many :census1860_records, dependent: :nullify, class_name: "Census1860Record", inverse_of: :person
-  has_many :census1870_records, dependent: :nullify, class_name: "Census1870Record", inverse_of: :person
-  has_many :census1880_records, dependent: :nullify, class_name: "Census1880Record", inverse_of: :person
-  has_many :census1900_records, dependent: :nullify, class_name: "Census1900Record", inverse_of: :person
-  has_many :census1910_records, dependent: :nullify, class_name: "Census1910Record", inverse_of: :person
-  has_many :census1920_records, dependent: :nullify, class_name: "Census1920Record", inverse_of: :person
-  has_many :census1930_records, dependent: :nullify, class_name: "Census1930Record", inverse_of: :person
-  has_many :census1940_records, dependent: :nullify, class_name: "Census1940Record", inverse_of: :person
-  has_many :census1950_records, dependent: :nullify, class_name: "Census1950Record", inverse_of: :person
-  has_and_belongs_to_many :photos, class_name: "Photograph", dependent: :nullify
+  has_many :census1850_records, dependent: :nullify, class_name: 'Census1850Record', inverse_of: :person
+  has_many :census1860_records, dependent: :nullify, class_name: 'Census1860Record', inverse_of: :person
+  has_many :census1870_records, dependent: :nullify, class_name: 'Census1870Record', inverse_of: :person
+  has_many :census1880_records, dependent: :nullify, class_name: 'Census1880Record', inverse_of: :person
+  has_many :census1900_records, dependent: :nullify, class_name: 'Census1900Record', inverse_of: :person
+  has_many :census1910_records, dependent: :nullify, class_name: 'Census1910Record', inverse_of: :person
+  has_many :census1920_records, dependent: :nullify, class_name: 'Census1920Record', inverse_of: :person
+  has_many :census1930_records, dependent: :nullify, class_name: 'Census1930Record', inverse_of: :person
+  has_many :census1940_records, dependent: :nullify, class_name: 'Census1940Record', inverse_of: :person
+  has_many :census1950_records, dependent: :nullify, class_name: 'Census1950Record', inverse_of: :person
+  has_and_belongs_to_many :photos, class_name: 'Photograph', dependent: :nullify
   has_and_belongs_to_many :audios, dependent: :nullify
   has_and_belongs_to_many :videos, dependent: :nullify
   has_and_belongs_to_many :narratives, dependent: :nullify
   has_and_belongs_to_many :localities
-  has_many :names, -> { order("last_name asc, first_name asc") },
-           class_name: "PersonName",
+  has_many :names, -> { order('last_name asc, first_name asc') },
+           class_name: 'PersonName',
            dependent: :destroy,
            autosave: true,
            inverse_of: :person
-  accepts_nested_attributes_for :names, allow_destroy: true, reject_if: proc { |p| p["first_name"].blank? || p["last_name"].blank? }
+  accepts_nested_attributes_for :names, allow_destroy: true, reject_if: proc { |p| p['first_name'].blank? || p['last_name'].blank? }
 
   validates :first_name, :last_name, :sex, :race, presence: true
 
   before_validation do
-    self.sex = nil if sex.blank? || sex == "on"
-    self.race = nil if race.blank? || race == "on"
+    self.sex = nil if sex.blank? || sex == 'on'
+    self.race = nil if race.blank? || race == 'on'
   end
 
   before_save :ensure_primary_name
@@ -81,14 +83,14 @@ class Person < ApplicationRecord
   scope :fuzzy_name_search, lambda { |names|
     names = names.is_a?(String) ? names.downcase.split : names
     where(id: PersonName.select(:person_id)
-                        .where(names.map { "person_names.searchable_name % ?" }.join(" AND "), *names)
-                        .where("person_names.person_id=people.id"))
+                        .where(names.map { 'person_names.searchable_name % ?' }.join(' AND '), *names)
+                        .where('person_names.person_id=people.id'))
   }
 
   scope :uncensused, lambda {
     qry = self
     CensusYears.each { |year| qry = qry.left_outer_joins(:"census#{year}_records") }
-    qry.where CensusYears.map { |year| "#{CensusRecord.for_year(year).table_name}.id IS NULL" }.join(" AND ")
+    qry.where CensusYears.map { |year| "#{CensusRecord.for_year(year).table_name}.id IS NULL" }.join(' AND ')
   }
 
   scope :with_census_records, lambda {
@@ -100,23 +102,23 @@ class Person < ApplicationRecord
   scope :with_multiple_names, lambda {
     all
       .joins(:names)
-      .group("people.id, person_names.last_name")
-      .having("COUNT(person_names.last_name) > 1")
+      .group('people.id, person_names.last_name')
+      .having('COUNT(person_names.last_name) > 1')
   }
 
   scope :photographed, lambda {
-    joins("INNER JOIN people_photographs ON people_photographs.person_id=people.id")
+    joins('INNER JOIN people_photographs ON people_photographs.person_id=people.id')
   }
 
   scope :name_fuzzy_matches, lambda { |names|
     possible_names = names.squish.split.map { |name| People::Nicknames.matches_for(name) }
-    query = joins(:names).group("people.id")
+    query = joins(:names).group('people.id')
     possible_names.each do |name_set|
       if name_set.length == 1
         name = name_set.first
-        query = query.where("person_names.last_name ILIKE ? OR person_names.first_name ILIKE ?", "#{name.downcase}%", "#{name.downcase}%")
+        query = query.where('person_names.last_name ILIKE ? OR person_names.first_name ILIKE ?', "#{name.downcase}%", "#{name.downcase}%")
       else
-        conditions = name_set.map { "person_names.first_name ILIKE ?" }.join(" OR ")
+        conditions = name_set.map { 'person_names.first_name ILIKE ?' }.join(' OR ')
         query = query.where(conditions, *name_set.map(&:downcase))
       end
     end
@@ -135,6 +137,12 @@ class Person < ApplicationRecord
     %w[names localities census_1850_records census_1860_records
        census_1870_records census_1880_records census_1900_records census_1910_records census_1920_records
        census_1930_records census_1940_records census_1950_records photos]
+  end
+
+  def race_choices
+    return RACES if race.blank? || RACES.include?(race)
+
+    RACES.dup << race
   end
 
   def variant_names
@@ -233,15 +241,15 @@ class Person < ApplicationRecord
   memoize :relatives
 
   def relation_to_head
-    census_records.select { |record| record.year >= 1880 }.map(&:relation_to_head).uniq.join(", ")
+    census_records.select { |record| record.year >= 1880 }.map(&:relation_to_head).uniq.join(', ')
   end
 
   def occupation
-    census_records.map(&:occupation).uniq.join(", ")
+    census_records.map(&:occupation).uniq.join(', ')
   end
 
   def address
-    census_records.map(&:street_address).compact_blank.uniq.join(", ")
+    census_records.map(&:street_address).compact_blank.uniq.join(', ')
   end
 
   def years

--- a/app/views/people/main/_form.html.slim
+++ b/app/views/people/main/_form.html.slim
@@ -41,9 +41,9 @@
     .card-body
       .row
         .col-4
-          = form.input :race, as: :radio_buttons, collection: Person.race_choices, coded: true
+          = form.input :race, as: :radio_buttons, collection: @person.race_choices, coded: true
         .col-4
-          = form.input :sex, as: :radio_buttons, collection: Census1900Record.sex_choices, coded: true
+          = form.input :sex, as: :radio_buttons, collection: Person.sex_choices, coded: true
         .col-4
           = form.input :ever_enslaved, as: :boolean, label: 'Ever Enslaved'
         .col-4

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe Person do
     end
   end
 
+  describe '#race_choices' do
+    context 'with an enumerated race' do
+      let(:person) { build(:person, race: 'W') }
+
+      it { expect(person.race_choices).to eq Person::RACES }
+    end
+
+    context 'with an unsual race' do
+      let(:person) { build(:person, race: 'Thai') }
+
+      it { expect(person.race_choices).to include('Thai') }
+    end
+  end
+
   describe '#estimated_birth_year' do
     context 'with a birth year' do
       let(:person) { build(:person, birth_year: 1872, is_birth_year_estimated: false) }


### PR DESCRIPTION
When saving a person with "Thai" race it gives an error. That's because "race" is on the form, but not showing a choice for "Other" or "Thai". This adds the unenumerated race as a radio button so that at least we don't lose it and prevent from using the edit form.