### PR TITLE
[410] reduce visibility of 999 birth year

### DIFF
--- a/app/decorators/census_record_decorator.rb
+++ b/app/decorators/census_record_decorator.rb
@@ -6,6 +6,8 @@ class CensusRecordDecorator < ApplicationDecorator
   include DecoratorFormatting
 
   def age
+    return 'Un.' if object&.age == 999
+
     if object.year == 1950
       object.age&.positive? ? object.age : '<1'
     elsif object.age_months

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -10,4 +10,10 @@ class PersonDecorator < ApplicationDecorator
   def locality_ids
     object.localities.map(&:short_name)
   end
+
+  def age
+    return 'Un.' if object&.age == 999
+
+    object&.age
+  end
 end

--- a/app/javascript/js/home_page.js
+++ b/app/javascript/js/home_page.js
@@ -10,7 +10,8 @@ $(document).ready(function() {
         document.location = item.data('url')
       },
       renderItem: function (item) {
-        return `<div class="autocomplete-suggestion" data-url="${item.url}"><div class="float-right">Born ${item.year}</div>${item.name}</div>`
+        const born = item.year ? `Born ${item.year}` : 'Unknown';
+        return `<div class="autocomplete-suggestion" data-url="${item.url}"><div class="float-right">${born}</div>${item.name}</div>`
       },
       delay: 250,
       cache: 0

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -206,6 +206,8 @@ class Person < ApplicationRecord
 
     match = census_records.first
     if match
+      return 'Un.' if match.age == 999
+
       diff = match.year - year
       (match.age || 0) - diff
     else

--- a/app/views/census_records/main/show.html.slim
+++ b/app/views/census_records/main/show.html.slim
@@ -118,7 +118,8 @@ div.mb-3.clearfix.d-flex.justify-content-between
                 th Relation
               th Occupation
           tbody
-            - @record.fellows.each do |row|
+            - @record.fellows.each do |raw_row|
+              - row = raw_row.decorate
               tr
                 td= link_to row.name, row
                 td= row.sex

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe Person do
       end
     end
 
+    context 'without a birth year and age of 999' do
+      let(:person) { build(:person, census1900_records: [build(:census1900_record, age: 999)]) }
+
+      it 'calculates the age based on the birth year of the census record' do
+        expect(person.age_in_year(1900)).to eq('Un.')
+      end
+    end
+
     context 'when the person is a baby' do
       let(:person) { build(:person, census1900_records: [build(:census1900_record, birth_year: 1900, age: 0)]) }
 


### PR DESCRIPTION
People get confused by 999 as an age, and it's weird to see a person's age as 1019 on the "likely person matches". Let's replace that case with "Un." for "unknown".