### PR TITLE
149 clean up person/building/census nav actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
   def can_people?
     Setting.can_people_public? || (user_signed_in? && Setting.can_people_private?)
   end
+
   helper_method :can_census?, :can_demographics?, :can_people?
 
   def check_administrator_role
@@ -64,7 +65,7 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html { render('cms/pages/page_404', status: :not_found, layout: 'cms') }
       format.json { render('cms/pages/page_404', status: :not_found, layout: 'cms') }
-      format.xml  { render('cms/pages/page_404', status: :not_found, layout: 'cms') }
+      format.xml { render('cms/pages/page_404', status: :not_found, layout: 'cms') }
     end
 
     true

--- a/app/helpers/item_navigation_helper.rb
+++ b/app/helpers/item_navigation_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ItemNavigationHelper
+  def previous_nav_link(path, text: 'Prev')
+    content_for :pills do
+      link_to path, class: 'btn btn-light' do
+        content_tag(:i, '', class: 'fa fa-chevron-left') +
+          content_tag(:span, " #{text}", class: 'd-none d-lg-inline')
+      end
+    end
+  end
+
+  def next_nav_link(path, text: 'Next')
+    content_for :pills do
+      link_to path, class: 'btn btn-light' do
+        content_tag(:span, "#{text} ", class: 'd-none d-lg-inline') +
+          content_tag(:i, '', class: 'fa fa-chevron-right')
+      end
+    end
+  end
+end

--- a/app/views/buildings/main/_merge_modal.html.slim
+++ b/app/views/buildings/main/_merge_modal.html.slim
@@ -1,8 +1,7 @@
 - if can?(:merge, Building) && @building.neighbors
-  - content_for :pills do
-    = link_to '#mergeModal', class: 'btn btn-light', data: { toggle: 'modal' } do
-      i.fa.fa-code-fork
-      | &nbsp; Merge
+  = link_to '#mergeModal', class: btn_class, data: { toggle: 'modal' } do
+    i.fa.fa-code-fork
+    | &nbsp; Merge
   - content_for :body_end do
     .modal.fade id="mergeModal"
       .modal-dialog.modal-lg

--- a/app/views/buildings/main/show.html.slim
+++ b/app/views/buildings/main/show.html.slim
@@ -1,26 +1,31 @@
 - set_page_title @building.proper_name? ? @building.name : @building.primary_street_address
 
 = render 'shared/flag_resolution', item: @building
-= render 'merge_modal'
 
-- content_for :pills do
-  - if can?(:create, Flag)
-    = render 'shared/flag_it', item: @building.object, item_class: 'btn btn-light'
-  - if can?(:update, @building.object)
-    = link_to [:edit, @building], class: 'btn btn-light' do
-      i.fa.fa-pencil
-      span.d-none.d-lg-inline
-        | &nbsp; Edit
-  - if can?(:review, @building.object) && !@building.reviewed?
-    = link_to 'Review', [:review, @building], class: 'btn btn-light', data: { method: :put }
-  = link_to 'View All', buildings_path, class: 'btn btn-light'
-  - if @navigation_neighbors.present?
-    - if @navigation_neighbors[:previous_id]
+- btn_class = 'btn btn-sm btn-secondary'
+div.mb-3.clearfix.d-flex.justify-content-between
+  div.mr-auto
+    - if can?(:create, Flag)
+      = render 'shared/flag_it', item: @building.object, item_class: btn_class
+    - if can?(:update, @building.object)
+      = link_to [:edit, @building], class: btn_class do
+        i.fa.fa-pencil
+        span.d-none.d-lg-inline
+          | &nbsp; Edit
+    - if can?(:review, @building.object) && !@building.reviewed?
+      = link_to 'Review', [:review, @building], class: btn_class, data: { method: :put }
+    = render 'merge_modal', btn_class:
+    = link_to 'View All', buildings_path, class: btn_class
+
+- if @navigation_neighbors.present?
+  - if @navigation_neighbors[:previous_id]
+    - content_for :pills do
       = link_to building_path(@navigation_neighbors[:previous_id]), class: 'btn btn-light' do
         i.fa.fa-chevron-left
         span.d-none.d-lg-inline
           | &nbsp; Prev
-    - if @navigation_neighbors[:next_id]
+  - if @navigation_neighbors[:next_id]
+    - content_for :pills do
       = link_to building_path(@navigation_neighbors[:next_id]), class: 'btn btn-light' do
         span.d-none.d-lg-inline
           | Next&nbsp;

--- a/app/views/buildings/main/show.html.slim
+++ b/app/views/buildings/main/show.html.slim
@@ -19,17 +19,9 @@ div.mb-3.clearfix.d-flex.justify-content-between
 
 - if @navigation_neighbors.present?
   - if @navigation_neighbors[:previous_id]
-    - content_for :pills do
-      = link_to building_path(@navigation_neighbors[:previous_id]), class: 'btn btn-light' do
-        i.fa.fa-chevron-left
-        span.d-none.d-lg-inline
-          | &nbsp; Prev
+    = previous_nav_link(building_path(@navigation_neighbors[:previous_id]))
   - if @navigation_neighbors[:next_id]
-    - content_for :pills do
-      = link_to building_path(@navigation_neighbors[:next_id]), class: 'btn btn-light' do
-        span.d-none.d-lg-inline
-          | Next&nbsp;
-        i.fa.fa-chevron-right
+    = next_nav_link(building_path(@navigation_neighbors[:next_id]))
 
 .row
   .col-12.col-md-8

--- a/app/views/census_records/main/show.html.slim
+++ b/app/views/census_records/main/show.html.slim
@@ -7,17 +7,9 @@
 
 - if @navigation
   - if @navigation[:previous_id]
-    - content_for :pills do
-      = link_to "/census/#{@record.year}/#{@navigation[:previous_id]}", class: 'btn btn-light' do
-        i.fa.fa-chevron-left
-        span.d-none.d-lg-inline
-          | &nbsp; Prev
+    = previous_nav_link("/census/#{@record.year}/#{@navigation[:previous_id]}")
   - if @navigation[:next_id]
-    - content_for :pills do
-      = link_to "/census/#{@record.year}/#{@navigation[:next_id]}", class: 'btn btn-light' do
-        span.d-none.d-lg-inline
-          | Next&nbsp;
-        i.fa.fa-chevron-right
+    = next_nav_link("/census/#{@record.year}/#{@navigation[:next_id]}")
 
 
 - btn_class = 'btn btn-sm btn-secondary'

--- a/app/views/census_records/main/show.html.slim
+++ b/app/views/census_records/main/show.html.slim
@@ -5,6 +5,21 @@
       li.breadcrumb-item= link_to @record.year, resource_class
       li.breadcrumb-item= link_to @record.census_scope, path_to_census_sheet(@record), class: 'float-right'
 
+- if @navigation
+  - if @navigation[:previous_id]
+    - content_for :pills do
+      = link_to "/census/#{@record.year}/#{@navigation[:previous_id]}", class: 'btn btn-light' do
+        i.fa.fa-chevron-left
+        span.d-none.d-lg-inline
+          | &nbsp; Prev
+  - if @navigation[:next_id]
+    - content_for :pills do
+      = link_to "/census/#{@record.year}/#{@navigation[:next_id]}", class: 'btn btn-light' do
+        span.d-none.d-lg-inline
+          | Next&nbsp;
+        i.fa.fa-chevron-right
+
+
 - btn_class = 'btn btn-sm btn-secondary'
 div.mb-3.clearfix.d-flex.justify-content-between
   div.mr-auto
@@ -23,17 +38,6 @@ div.mb-3.clearfix.d-flex.justify-content-between
     - if !@record.reviewed? && can?(:review, @record)
       | &nbsp;
       => link_to 'Review', [:reviewed, @record], class: 'btn btn-sm btn-danger', data: { method: :put, confirm: 'You are about to make this census record public.' }
-    - if @navigation
-      - if @navigation[:previous_id]
-        = link_to "/census/#{@record.year}/#{@navigation[:previous_id]}", class: 'btn btn-sm btn-secondary' do
-          i.fa.fa-chevron-left
-          span.d-none.d-lg-inline
-            | &nbsp; Prev
-      - if @navigation[:next_id]
-        = link_to "/census/#{@record.year}/#{@navigation[:next_id]}", class: 'btn btn-sm btn-secondary' do
-          span.d-none.d-lg-inline
-            | Next&nbsp;
-          i.fa.fa-chevron-right
 
   - if can?(:create, CensusRecord)
     .add-another-form.ml-auto.d-flex.justify-content-right

--- a/app/views/people/main/_merge_modal.html.slim
+++ b/app/views/people/main/_merge_modal.html.slim
@@ -1,9 +1,8 @@
 - if can?(:merge, Person)
-  - content_for :pills do
-    = link_to '#mergeModal', class: 'btn btn-light', data: { toggle: 'modal' }, title: 'Merge' do
-      i.fa.fa-code-fork
-      span.d-none.d-lg-inline
-        | &nbsp; Merge
+  = link_to '#mergeModal', class: btn_class, data: { toggle: 'modal' }, title: 'Merge' do
+    i.fa.fa-code-fork
+    span.d-none.d-lg-inline
+      | &nbsp; Merge
   - content_for :body_end do
     .modal.fade id="mergeModal"
       .modal-dialog.modal-lg

--- a/app/views/people/main/show.html.slim
+++ b/app/views/people/main/show.html.slim
@@ -20,17 +20,9 @@ div.mb-3.clearfix.d-flex.justify-content-between
           | &nbsp; Delete
 - if @navigation_neighbors.present?
   - if @navigation_neighbors[:previous_id]
-    - content_for :pills do
-      = link_to person_path(@navigation_neighbors[:previous_id]), class: 'btn btn-light' do
-        i.fa.fa-chevron-left
-        span.d-none.d-lg-inline
-          | &nbsp; Prev
+    = previous_nav_link(person_path(@navigation_neighbors[:previous_id]))
   - if @navigation_neighbors[:next_id]
-    - content_for :pills do
-      = link_to person_path(@navigation_neighbors[:next_id]), class: 'btn btn-light' do
-        span.d-none.d-lg-inline
-          | Next&nbsp;
-        i.fa.fa-chevron-right
+    = next_nav_link(person_path(@navigation_neighbors[:next_id]))
 
 .list-group.mb-3
   - names = @person.variant_names

--- a/app/views/people/main/show.html.slim
+++ b/app/views/people/main/show.html.slim
@@ -1,28 +1,32 @@
 - set_page_title @person.name
 = render 'shared/flag_resolution', item: @person
-= render 'merge_modal'
-- content_for :pills do
-  - if can_people? || can?(:read, Person)
-    = link_to 'View All', people_path, class: 'btn btn-light'
-  - if can?(:create, Flag)
-    = render 'shared/flag_it', item: @person, item_class: 'btn btn-light'
-  - if can?(:update, @person)
-    = link_to [:edit, @person], class: 'btn btn-light' do
-      i.fa.fa-pencil
-      span.d-none.d-lg-inline
-        | &nbsp; Edit
-  - if can?(:destroy, @person) && @person.census_records.blank?
-    = link_to @person, class: 'btn btn-light', data: { method: :delete, confirm: 'Are you sure?' } do
-      i.fa.fa-trash
-      span.d-none.d-lg-inline
-        | &nbsp; Delete
-  - if @navigation_neighbors.present?
-    - if @navigation_neighbors[:previous_id]
+- btn_class = 'btn btn-sm btn-secondary'
+div.mb-3.clearfix.d-flex.justify-content-between
+  div.mr-auto
+    - if can_people? || can?(:read, Person)
+      = link_to 'View All', people_path, class: btn_class
+    - if can?(:create, Flag)
+      = render 'shared/flag_it', item: @person, item_class: btn_class
+    - if can?(:update, @person)
+      = link_to [:edit, @person], class: btn_class do
+        i.fa.fa-pencil
+        span.d-none.d-lg-inline
+          | &nbsp; Edit
+    = render 'merge_modal', btn_class:
+    - if can?(:destroy, @person) && @person.census_records.blank?
+      = link_to @person, class: btn_class, data: { method: :delete, confirm: 'Are you sure?' } do
+        i.fa.fa-trash
+        span.d-none.d-lg-inline
+          | &nbsp; Delete
+- if @navigation_neighbors.present?
+  - if @navigation_neighbors[:previous_id]
+    - content_for :pills do
       = link_to person_path(@navigation_neighbors[:previous_id]), class: 'btn btn-light' do
         i.fa.fa-chevron-left
         span.d-none.d-lg-inline
           | &nbsp; Prev
-    - if @navigation_neighbors[:next_id]
+  - if @navigation_neighbors[:next_id]
+    - content_for :pills do
       = link_to person_path(@navigation_neighbors[:next_id]), class: 'btn btn-light' do
         span.d-none.d-lg-inline
           | Next&nbsp;


### PR DESCRIPTION
Closes #149 

Moves the button bar of local actions for people and buildings to the same place and style as the census records. Also found that the back and next buttons wanted to remain there, so moved them to the local nav place for all three pages.