### PR TITLE
486 - use locality name instead of address city in buiding name

### DIFF
--- a/app/services/building_from_address.rb
+++ b/app/services/building_from_address.rb
@@ -12,8 +12,7 @@ class BuildingFromAddress
     return original_address.building if original_address.persisted?
     return modern_address.building if modern_address.persisted?
 
-    building = Building.new name: modern_address.address,
-                            locality: record.locality,
+    building = Building.new locality: record.locality,
                             building_type_ids: [3] # residence
 
     modern_address.is_primary = true

--- a/spec/services/building_from_address_spec.rb
+++ b/spec/services/building_from_address_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe BuildingFromAddress do
   it 'has the correct primary street address' do
     expect(result.primary_street_address).to eq('405 N Tioga St Ithaca')
   end
+
+  it 'uses locality name in building name instead of address city' do
+    locality = create(:locality, name: 'City of Ithaca', short_name: 'Ithaca')
+    record.locality = locality
+    building = described_class.new(record).perform
+    expect(building.name).to eq('405 N Tioga St City of Ithaca')
+  end
 end


### PR DESCRIPTION
Lots of building names with "Ithaca" where "City of Ithaca" or "Town of Ithaca" would be better.