### PR TITLE
436 spurious duplicate notices

### DIFF
--- a/app/services/next_census_record_attributes.rb
+++ b/app/services/next_census_record_attributes.rb
@@ -38,6 +38,8 @@ class NextCensusRecordAttributes
   end
 
   def at_end_of_page?
+    return false unless record.line_number
+
     record.line_number == record.per_page
   end
 


### PR DESCRIPTION
Maybe fixes #436 

At least patches some logical inconsistency around what to do when `record.line_number` is nil.