### PR TITLE
484 Institution not name/type in 1870

### DIFF
--- a/app/services/census_field_list_generator.rb
+++ b/app/services/census_field_list_generator.rb
@@ -41,7 +41,7 @@ class CensusFieldListGenerator
     @fields << 'ward' unless klass.year <= 1880
     @fields << 'enum_dist' if klass.year >= 1880
     @fields.concat %w[street_address]
-    if klass == Census1950Record || klass.year < 1880
+    if klass == Census1950Record || klass.year < 1870
       @fields.concat %w[institution_name institution_type]
     else
       @fields << 'institution'

--- a/app/services/census_grid_translator.rb
+++ b/app/services/census_grid_translator.rb
@@ -72,6 +72,7 @@ class CensusGridTranslator
     notes: 160,
     coded_occupation_name: 250,
     coded_industry_name: 250,
+    institution: 130,
     institution_name: 130,
     institution_type: 130
   }.freeze


### PR DESCRIPTION
Fixes #484, in which 1870 has only Institution field but search treats it like it has Institution Name and Type fields.