### PR TITLE
501: Institution handling on census with institution field

### DIFF
--- a/app/controllers/census_records/main_controller.rb
+++ b/app/controllers/census_records/main_controller.rb
@@ -238,7 +238,7 @@ module CensusRecords
       if params[:context] && params[:context] == 'person'
         redirect_to @record.person
       elsif params[:then].present?
-        attributes = NextCensusRecordAttributes.new(@record, params[:then]).attributes
+        attributes = NextCensusRecordAttributes.call(@record, params[:then])
         redirect_to send(:"new_census#{year}_record_path", attributes:)
       else
         redirect_to @record

--- a/app/services/next_census_record_attributes.rb
+++ b/app/services/next_census_record_attributes.rb
@@ -17,24 +17,30 @@ class NextCensusRecordAttributes
   }.freeze
 
   def self.call(record, action)
-    new(record, action).attributes
+    new(record, action).call
   end
 
   def initialize(record, action)
     @record = record
     @action = action
-    prefill_attributes
-    prefill_sheet_side_line
   end
 
-  attr_reader :record, :action, :attributes
+  def call
+    prefill_attributes
+    prefill_sheet_side_line
+    attributes
+  end
+
+  attr_reader :record, :action
 
   private
 
+  attr_reader :attributes
+
   def prefill_attributes
-    @attributes = fields.each_with_object({}) { |item, hash|
+    @attributes = fields.each_with_object({}) do |item, hash|
       hash[item] = record.public_send(item) if record.respond_to?(item)
-    }
+    end
   end
 
   def prefill_sheet_side_line

--- a/app/services/next_census_record_attributes.rb
+++ b/app/services/next_census_record_attributes.rb
@@ -13,8 +13,12 @@ class NextCensusRecordAttributes
     'dwelling' => %i[dwelling_number street_house_number
                      street_prefix street_suffix street_name apartment_number building_id],
     'family' => %i[dwelling_number street_house_number street_prefix street_suffix street_name apartment_number
-                   family_id building_id last_name institution_type institution_name]
+                   family_id building_id last_name institution institution_type institution_name]
   }.freeze
+
+  def self.call(record, action)
+    new(record, action).attributes
+  end
 
   def initialize(record, action)
     @record = record

--- a/spec/services/next_census_record_attributes_spec.rb
+++ b/spec/services/next_census_record_attributes_spec.rb
@@ -3,11 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe NextCensusRecordAttributes do
-  let(:result) { described_class.new(record, action) }
-
-  let(:record) { Census1900Record.new }
-
-  describe 'attributes' do
+  shared_examples 'common record setup' do
     before do
       record.page_number = 1
       record.page_side = 'A'
@@ -25,81 +21,159 @@ RSpec.describe NextCensusRecordAttributes do
       record.street_suffix = 'St'
       record.building_id = 1
     end
+  end
 
+  describe 'attributes' do
     context 'with same enumeration district' do
+      let(:record) { Census1900Record.new }
       let(:action) { 'enumeration' }
+      let(:result) { described_class.call(record, action) }
+
+      include_examples 'common record setup'
 
       it 'has the correct attributes' do
-        expect(result.attributes[:county]).to eq(record.county)
-        expect(result.attributes[:city]).to eq(record.city)
-        expect(result.attributes[:ward]).to eq(record.ward)
-        expect(result.attributes[:enum_dist]).to eq(record.enum_dist)
-        expect(result.attributes[:locality_id]).to eq(record.locality_id)
+        expect(result[:county]).to eq(record.county)
+        expect(result[:city]).to eq(record.city)
+        expect(result[:ward]).to eq(record.ward)
+        expect(result[:enum_dist]).to eq(record.enum_dist)
+        expect(result[:locality_id]).to eq(record.locality_id)
         %i[dwelling_number family_id street_house_number
            street_prefix street_name street_suffix building_id].each do |attribute|
-          expect(result.attributes[attribute]).to be_nil
+          expect(result[attribute]).to be_nil
         end
       end
     end
 
     context 'with the same street' do
+      let(:record) { Census1900Record.new }
       let(:action) { 'street' }
+      let(:result) { described_class.call(record, action) }
+
+      include_examples 'common record setup'
 
       it 'has the correct attributes' do
-        expect(result.attributes[:county]).to eq(record.county)
-        expect(result.attributes[:city]).to eq(record.city)
-        expect(result.attributes[:ward]).to eq(record.ward)
-        expect(result.attributes[:enum_dist]).to eq(record.enum_dist)
-        expect(result.attributes[:locality_id]).to eq(record.locality_id)
-        expect(result.attributes[:street_prefix]).to eq(record.street_prefix)
-        expect(result.attributes[:street_name]).to eq(record.street_name)
-        expect(result.attributes[:street_suffix]).to eq(record.street_suffix)
+        expect(result[:county]).to eq(record.county)
+        expect(result[:city]).to eq(record.city)
+        expect(result[:ward]).to eq(record.ward)
+        expect(result[:enum_dist]).to eq(record.enum_dist)
+        expect(result[:locality_id]).to eq(record.locality_id)
+        expect(result[:street_prefix]).to eq(record.street_prefix)
+        expect(result[:street_name]).to eq(record.street_name)
+        expect(result[:street_suffix]).to eq(record.street_suffix)
         %i[dwelling_number family_id street_house_number building_id].each do |attribute|
-          expect(result.attributes[attribute]).to be_nil
+          expect(result[attribute]).to be_nil
         end
       end
     end
 
     context 'with the same dwelling' do
+      let(:record) { Census1900Record.new }
       let(:action) { 'dwelling' }
+      let(:result) { described_class.call(record, action) }
+
+      include_examples 'common record setup'
 
       it 'has the correct attributes' do
-        expect(result.attributes[:county]).to eq(record.county)
-        expect(result.attributes[:city]).to eq(record.city)
-        expect(result.attributes[:ward]).to eq(record.ward)
-        expect(result.attributes[:enum_dist]).to eq(record.enum_dist)
-        expect(result.attributes[:locality_id]).to eq(record.locality_id)
-        expect(result.attributes[:dwelling_number]).to eq(record.dwelling_number)
-        expect(result.attributes[:family_id]).to be_nil
-        expect(result.attributes[:street_house_number]).to eq(record.street_house_number)
-        expect(result.attributes[:street_prefix]).to eq(record.street_prefix)
-        expect(result.attributes[:street_name]).to eq(record.street_name)
-        expect(result.attributes[:street_suffix]).to eq(record.street_suffix)
-        expect(result.attributes[:building_id]).to eq(record.building_id)
+        expect(result[:county]).to eq(record.county)
+        expect(result[:city]).to eq(record.city)
+        expect(result[:ward]).to eq(record.ward)
+        expect(result[:enum_dist]).to eq(record.enum_dist)
+        expect(result[:locality_id]).to eq(record.locality_id)
+        expect(result[:dwelling_number]).to eq(record.dwelling_number)
+        expect(result[:family_id]).to be_nil
+        expect(result[:street_house_number]).to eq(record.street_house_number)
+        expect(result[:street_prefix]).to eq(record.street_prefix)
+        expect(result[:street_name]).to eq(record.street_name)
+        expect(result[:street_suffix]).to eq(record.street_suffix)
+        expect(result[:building_id]).to eq(record.building_id)
       end
     end
 
     context 'with same family' do
-      let(:action) { 'family' }
+      context 'for censuses with institution field (1870-1940)' do
+        let(:record) { Census1900Record.new }
+        let(:action) { 'family' }
+        let(:result) { described_class.call(record, action) }
 
-      it 'has the correct attributes' do
-        expect(result.attributes[:county]).to eq(record.county)
-        expect(result.attributes[:city]).to eq(record.city)
-        expect(result.attributes[:ward]).to eq(record.ward)
-        expect(result.attributes[:enum_dist]).to eq(record.enum_dist)
-        expect(result.attributes[:locality_id]).to eq(record.locality_id)
-        expect(result.attributes[:dwelling_number]).to eq(record.dwelling_number)
-        expect(result.attributes[:family_id]).to eq(record.family_id)
-        expect(result.attributes[:street_house_number]).to eq(record.street_house_number)
-        expect(result.attributes[:street_prefix]).to eq(record.street_prefix)
-        expect(result.attributes[:street_name]).to eq(record.street_name)
-        expect(result.attributes[:street_suffix]).to eq(record.street_suffix)
-        expect(result.attributes[:building_id]).to eq(record.building_id)
+        include_examples 'common record setup'
+
+        before do
+          record.institution = 'State Hospital'
+        end
+
+        it 'copies institution field and excludes institution_type/institution_name' do
+          expect(result[:county]).to eq(record.county)
+          expect(result[:city]).to eq(record.city)
+          expect(result[:ward]).to eq(record.ward)
+          expect(result[:enum_dist]).to eq(record.enum_dist)
+          expect(result[:locality_id]).to eq(record.locality_id)
+          expect(result[:dwelling_number]).to eq(record.dwelling_number)
+          expect(result[:family_id]).to eq(record.family_id)
+          expect(result[:street_house_number]).to eq(record.street_house_number)
+          expect(result[:street_prefix]).to eq(record.street_prefix)
+          expect(result[:street_name]).to eq(record.street_name)
+          expect(result[:street_suffix]).to eq(record.street_suffix)
+          expect(result[:building_id]).to eq(record.building_id)
+          expect(result[:institution]).to eq(record.institution)
+          expect(result[:institution_type]).to be_nil
+          expect(result[:institution_name]).to be_nil
+        end
+      end
+
+      context 'for censuses with institution_type and institution_name (1850, 1860, 1950)' do
+        let(:record) { Census1860Record.new }
+        let(:action) { 'family' }
+        let(:result) { described_class.call(record, action) }
+
+        include_examples 'common record setup'
+
+        before do
+          record.institution_type = 'Prison'
+          record.institution_name = 'Auburn State Prison'
+        end
+
+        it 'copies institution_type and institution_name fields and excludes institution' do
+          expect(result[:county]).to eq(record.county)
+          expect(result[:city]).to eq(record.city)
+          expect(result[:ward]).to eq(record.ward)
+          expect(result[:enum_dist]).to eq(record.enum_dist)
+          expect(result[:locality_id]).to eq(record.locality_id)
+          expect(result[:dwelling_number]).to eq(record.dwelling_number)
+          expect(result[:family_id]).to eq(record.family_id)
+          expect(result[:street_house_number]).to eq(record.street_house_number)
+          expect(result[:street_prefix]).to eq(record.street_prefix)
+          expect(result[:street_name]).to eq(record.street_name)
+          expect(result[:street_suffix]).to eq(record.street_suffix)
+          expect(result[:building_id]).to eq(record.building_id)
+          expect(result[:institution_type]).to eq(record.institution_type)
+          expect(result[:institution_name]).to eq(record.institution_name)
+          expect(result[:institution]).to be_nil
+        end
+      end
+
+      context 'for 1950 census (also has institution_type and institution_name)' do
+        let(:record) { Census1950Record.new }
+        let(:action) { 'family' }
+        let(:result) { described_class.call(record, action) }
+
+        include_examples 'common record setup'
+
+        before do
+          record.institution_type = 'Hospital'
+          record.institution_name = 'General Hospital'
+        end
+
+        it 'copies institution_type and institution_name fields' do
+          expect(result[:institution_type]).to eq(record.institution_type)
+          expect(result[:institution_name]).to eq(record.institution_name)
+          expect(result[:institution]).to be_nil
+        end
       end
     end
   end
 
   describe 'pagination' do
+    let(:record) { Census1900Record.new }
     let(:action) { 'enumeration' }
 
     context 'when not at the end of page or side' do
@@ -110,9 +184,10 @@ RSpec.describe NextCensusRecordAttributes do
       end
 
       it 'goes to the next line' do
-        expect(result.attributes[:page_number]).to eq(1)
-        expect(result.attributes[:page_side]).to eq('A')
-        expect(result.attributes[:line_number]).to eq(2)
+        result = described_class.call(record, action)
+        expect(result[:page_number]).to eq(1)
+        expect(result[:page_side]).to eq('A')
+        expect(result[:line_number]).to eq(2)
       end
     end
 
@@ -124,9 +199,10 @@ RSpec.describe NextCensusRecordAttributes do
       end
 
       it 'goes to the first line of side B' do
-        expect(result.attributes[:page_number]).to eq(1)
-        expect(result.attributes[:page_side]).to eq('B')
-        expect(result.attributes[:line_number]).to eq(1)
+        result = described_class.call(record, action)
+        expect(result[:page_number]).to eq(1)
+        expect(result[:page_side]).to eq('B')
+        expect(result[:line_number]).to eq(1)
       end
     end
 
@@ -138,9 +214,10 @@ RSpec.describe NextCensusRecordAttributes do
       end
 
       it 'goes to the first line of side A of next page' do
-        expect(result.attributes[:page_number]).to eq(2)
-        expect(result.attributes[:page_side]).to eq('A')
-        expect(result.attributes[:line_number]).to eq(1)
+        result = described_class.call(record, action)
+        expect(result[:page_number]).to eq(2)
+        expect(result[:page_side]).to eq('A')
+        expect(result[:line_number]).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Some censuses have `institution_type` and `institution_name`. Others have `institution`. We currently handle the former case but not the latter when starting the next census record from the current census record.