### PR TITLE
#526 bring back full screen miniforge

### DIFF
--- a/app/assets/stylesheets/_forge.scss
+++ b/app/assets/stylesheets/_forge.scss
@@ -162,6 +162,12 @@
       width: 100%;
       height: 300px;
       z-index: 1;
+
+      &:fullscreen,
+      &:-webkit-full-screen {
+        width: 100%;
+        height: 100%;
+      }
     }
     select {
       margin-bottom: 30px;
@@ -192,6 +198,14 @@
     z-index:120;
   }
 }
+.leaflet-control-fullscreen a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  color: #333;
+}
+
 .leaflet-popup-content {
   div.row {
     margin-left:0;

--- a/app/javascript/miniforge/Map.jsx
+++ b/app/javascript/miniforge/Map.jsx
@@ -5,6 +5,7 @@ import { addStyleImageMissingFallback } from '../forge/maplibreImageFallback'
 import loadWMS from '../forge/wms'
 import { getMainIcon, generateMarkers, highlightMarker, unhighlightMarker } from '../forge/mapFunctions'
 import { moveBuilding, highlight } from '../forge/actions'
+import { addFullscreenControl } from './fullscreenControl'
 import { useDispatch, useSelector } from "react-redux";
 
 export const Map = () => {
@@ -58,6 +59,8 @@ export const Map = () => {
         null,
         { position: 'bottomleft' }
       ).addTo(leafletMap);
+
+      addFullscreenControl(leafletMap, mapDivRef.current)
 
       setMap(leafletMap);
     }

--- a/app/javascript/miniforge/index.jsx
+++ b/app/javascript/miniforge/index.jsx
@@ -1,5 +1,6 @@
 import ReactDOM from "react-dom";
 import MiniForge from "./App";
+import { exitMapFullscreen } from './fullscreenControl';
 import React from "react";
 
 let reactRoot = null;
@@ -25,6 +26,7 @@ const initializeMiniForge = () => {
 };
 
 const cleanupMiniForge = () => {
+    exitMapFullscreen();
     if (reactRoot) {
         ReactDOM.unmountComponentAtNode(reactRoot);
         reactRoot = null;


### PR DESCRIPTION
Fullscreen map was a feature of Google Maps that doesn't exist as such on Leaflet/OSM. So put together a manually driven equivalent that blows up the map element to full screen when you click the button.