### PR TITLE
#527 house numbers on the maps

### DIFF
--- a/app/javascript/controllers/photo_wizard_controller.js
+++ b/app/javascript/controllers/photo_wizard_controller.js
@@ -2,6 +2,7 @@ import { Controller } from 'stimulus'
 import L from 'leaflet'
 import '@maplibre/maplibre-gl-leaflet'
 import { addStyleImageMissingFallback } from '../forge/maplibreImageFallback'
+import { addHousenumbers } from '../forge/maplibreHousenumbers'
 import { getMainIcon } from '../forge/mapFunctions'
 
 export default class extends Controller {
@@ -192,7 +193,9 @@ export default class extends Controller {
       maxZoom: 22,
       attribution: '&copy; <a href="https://openfreemap.org">OpenFreeMap</a> &copy; <a href="https://openmaptiles.org">OpenMapTiles</a> Data from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     }).addTo(map)
-    addStyleImageMissingFallback(streetLayer.getMaplibreMap())
+    const maplibreMap = streetLayer.getMaplibreMap()
+    addStyleImageMissingFallback(maplibreMap)
+    addHousenumbers(maplibreMap)
 
     const marker = L.marker(loc, {
       icon: getMainIcon(),

--- a/app/javascript/forge/Map.jsx
+++ b/app/javascript/forge/Map.jsx
@@ -7,6 +7,7 @@ import L from 'leaflet';
 import 'leaflet.markercluster';
 import '@maplibre/maplibre-gl-leaflet';
 import { addStyleImageMissingFallback } from './maplibreImageFallback';
+import { addHousenumbers } from './maplibreHousenumbers';
 
 export const Map = () => {
   const props = useSelector(state => ({ ...state.layers, ...state.buildings, ...state.search }))
@@ -31,7 +32,9 @@ export const Map = () => {
         maxZoom: 22,
         attribution: '&copy; <a href="https://openfreemap.org">OpenFreeMap</a> &copy; <a href="https://openmaptiles.org">OpenMapTiles</a> Data from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       }).addTo(mapRef.current);
-      addStyleImageMissingFallback(street.getMaplibreMap());
+      const maplibreMap = street.getMaplibreMap();
+      addStyleImageMissingFallback(maplibreMap);
+      addHousenumbers(maplibreMap);
 
       const satellite = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: '&copy; Esri',

--- a/app/javascript/forge/maplibreHousenumbers.js
+++ b/app/javascript/forge/maplibreHousenumbers.js
@@ -1,0 +1,40 @@
+const HOUSENUMBER_LAYER = {
+  id: 'housenumber',
+  type: 'symbol',
+  source: 'openmaptiles',
+  'source-layer': 'housenumber',
+  minzoom: 17,
+  filter: ['match', ['geometry-type'], ['MultiPoint', 'Point'], true, false],
+  layout: {
+    'text-field': ['to-string', ['get', 'housenumber']],
+    'text-font': ['Noto Sans Regular'],
+    'text-size': 11,
+  },
+  paint: {
+    'text-color': '#443322',
+    'text-halo-color': 'rgba(255, 255, 255, 0.85)',
+    'text-halo-width': 1.2,
+  },
+}
+
+/**
+ * Adds house number labels to a MapLibre GL map using the openmaptiles source.
+ * OpenFreeMap styles omit this layer even though the vector tiles include it.
+ */
+export function addHousenumbers(maplibreMap) {
+  if (!maplibreMap || !maplibreMap.on) return
+
+  const addLayer = () => {
+    if (maplibreMap.getLayer('housenumber')) return
+    if (!maplibreMap.getSource('openmaptiles')) return
+
+    const beforeId = maplibreMap.getLayer('label_other') ? 'label_other' : undefined
+    maplibreMap.addLayer(HOUSENUMBER_LAYER, beforeId)
+  }
+
+  if (maplibreMap.isStyleLoaded()) {
+    addLayer()
+  } else {
+    maplibreMap.once('load', addLayer)
+  }
+}

--- a/app/javascript/miniforge/Map.jsx
+++ b/app/javascript/miniforge/Map.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react'
 import L from 'leaflet'
 import '@maplibre/maplibre-gl-leaflet'
 import { addStyleImageMissingFallback } from '../forge/maplibreImageFallback'
+import { addHousenumbers } from '../forge/maplibreHousenumbers'
 import loadWMS from '../forge/wms'
 import { getMainIcon, generateMarkers, highlightMarker, unhighlightMarker } from '../forge/mapFunctions'
 import { moveBuilding, highlight } from '../forge/actions'
@@ -46,7 +47,9 @@ export const Map = () => {
         maxZoom: 22,
         attribution: '&copy; <a href="https://openfreemap.org">OpenFreeMap</a> &copy; <a href="https://openmaptiles.org">OpenMapTiles</a> Data from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       }).addTo(leafletMap);
-      addStyleImageMissingFallback(streetLayer.getMaplibreMap());
+      const maplibreMap = streetLayer.getMaplibreMap();
+      addStyleImageMissingFallback(maplibreMap);
+      addHousenumbers(maplibreMap);
 
       const satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: '&copy; Esri',

--- a/app/javascript/miniforge/fullscreenControl.js
+++ b/app/javascript/miniforge/fullscreenControl.js
@@ -1,0 +1,85 @@
+import L from 'leaflet'
+
+const requestFullscreen = (element) => {
+  const method = element.requestFullscreen || element.webkitRequestFullscreen
+  return method?.call(element)
+}
+
+const exitFullscreen = () => {
+  const method = document.exitFullscreen || document.webkitExitFullscreen
+  return method?.call(document)
+}
+
+export const fullscreenElement = () => document.fullscreenElement || document.webkitFullscreenElement
+
+export const exitMapFullscreen = () => {
+  if (fullscreenElement()) {
+    exitFullscreen()
+  }
+}
+
+const isFullscreen = (container) => fullscreenElement() === container
+
+const toggleFullscreen = (container, map) => {
+  if (isFullscreen(container)) {
+    exitFullscreen()
+  } else {
+    requestFullscreen(container)
+  }
+}
+
+export const addFullscreenControl = (map, container) => {
+  if (!container) return null
+  const canFullscreen = document.fullscreenEnabled || document.webkitFullscreenEnabled
+  if (!canFullscreen) return null
+
+  const control = L.Control.extend({
+    onAdd() {
+      const wrapper = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-fullscreen')
+      const button = L.DomUtil.create('a', '', wrapper)
+      button.href = '#'
+      button.title = 'Full screen'
+      button.setAttribute('role', 'button')
+      button.setAttribute('aria-label', 'Full screen')
+      button.innerHTML = '<i class="fa fa-arrows-alt" aria-hidden="true"></i>'
+
+      const updateButton = () => {
+        const active = isFullscreen(container)
+        button.title = active ? 'Exit full screen' : 'Full screen'
+        button.setAttribute('aria-label', button.title)
+        button.innerHTML = active
+          ? '<i class="fa fa-compress" aria-hidden="true"></i>'
+          : '<i class="fa fa-arrows-alt" aria-hidden="true"></i>'
+      }
+
+      const onFullscreenChange = () => {
+        updateButton()
+        setTimeout(() => map.invalidateSize(), 100)
+        if (isFullscreen(container)) {
+          map.scrollWheelZoom.enable()
+        } else {
+          map.scrollWheelZoom.disable()
+        }
+      }
+
+      document.addEventListener('fullscreenchange', onFullscreenChange)
+      document.addEventListener('webkitfullscreenchange', onFullscreenChange)
+
+      L.DomEvent.disableClickPropagation(wrapper)
+      L.DomEvent.on(button, 'click', (event) => {
+        L.DomEvent.stopPropagation(event)
+        L.DomEvent.preventDefault(event)
+        toggleFullscreen(container, map)
+      })
+
+      this._onFullscreenChange = onFullscreenChange
+      return wrapper
+    },
+    onRemove() {
+      document.removeEventListener('fullscreenchange', this._onFullscreenChange)
+      document.removeEventListener('webkitfullscreenchange', this._onFullscreenChange)
+    },
+  })
+
+  return new control({ position: 'topright' }).addTo(map)
+}


### PR DESCRIPTION
OSM has street numbers on the map layers, but OpenFreeMaps by default doesn't include them. This has a workaround to add the house numbers symbol layer at zoom 17 and above.