### PR TITLE
#524 1870 let census sheet filter go over 200

### DIFF
--- a/app/services/census_record_search.rb
+++ b/app/services/census_record_search.rb
@@ -123,6 +123,14 @@ class CensusRecordSearch < SearchQueryBuilder
     end
   end
 
+  def sheet_number_options
+    selected = s[:page_number_eq].to_i
+    query = entity_class
+    query = query.where(locality_id: Current.locality_id) if Current.locality_id
+    max_sheet = [query.maximum(:page_number).to_i, selected, 200].max
+    (1..max_sheet).to_a
+  end
+
   def all_fields
     CensusFieldListGenerator.new(form_fields_config).render
   end

--- a/app/services/census_record_search.rb
+++ b/app/services/census_record_search.rb
@@ -6,6 +6,8 @@
 # 3. Converts the hash to a CSV string
 
 class CensusRecordSearch < SearchQueryBuilder
+  PAGE_NUMBER_MAX = 10_000
+
   attr_accessor :page, :s, :f, :g, :user, :sort, :from, :to, :scope, :entity_class, :form_fields_config
 
   def census_scope_search?
@@ -123,12 +125,11 @@ class CensusRecordSearch < SearchQueryBuilder
     end
   end
 
-  def sheet_number_options
+  def max_page_number
     selected = s[:page_number_eq].to_i
     query = entity_class
     query = query.where(locality_id: Current.locality_id) if Current.locality_id
-    max_sheet = [query.maximum(:page_number).to_i, selected, 200].max
-    (1..max_sheet).to_a
+    [query.maximum(:page_number).to_i, selected].max
   end
 
   def all_fields
@@ -149,5 +150,24 @@ class CensusRecordSearch < SearchQueryBuilder
 
   def facets
     form_fields_config.facets
+  end
+
+  private
+
+  def prepare_search_filters
+    super
+    normalize_page_number_filter!
+  end
+
+  def normalize_page_number_filter!
+    value = @s[:page_number_eq]
+    return if value.blank?
+
+    page = value.to_i
+    if page.positive? && value.to_s.match?(/\A\d+\z/)
+      @s[:page_number_eq] = page.clamp(1, PAGE_NUMBER_MAX).to_s
+    else
+      @s.delete(:page_number_eq)
+    end
   end
 end

--- a/app/views/shared/_grid_filters.html.slim
+++ b/app/views/shared/_grid_filters.html.slim
@@ -63,17 +63,17 @@
           .row
             - if controller.year >= 1880
               .col-3
-                label for="s_ward_eq" Ward
+                label for="s_ward_eq"= translated_label(resource_class, :ward)
                 input.form-control#s_ward_eq type="search" name="s[ward_eq]" value=@search.s[:ward_eq]
               .col-3
-                label for="s_enum_dist_eq" Enum. Dist.
+                label for="s_enum_dist_eq"= translated_label(resource_class, :enum_dist)
                 input.form-control#s_enum_dist_eq type="search" name="s[enum_dist_eq]" value=@search.s[:enum_dist_eq]
             .col-3
-              label for="s_page_number_eq" Sheet
-              = select_tag 's[page_number_eq]', options_for_select((1..200).map, @search.s[:page_number_eq]), include_blank: true, class: 'form-control'
+              label for="s_page_number_eq"= translated_label(resource_class, :page_number)
+              = select_tag 's[page_number_eq]', options_for_select(@search.sheet_number_options, @search.s[:page_number_eq]), include_blank: true, class: 'form-control'
             - if controller.year < 1950 and controller.year >= 1880
               .col-3
-                label for="s_page_side_eq" Side
+                label for="s_page_side_eq"= translated_label(resource_class, :page_side)
                 = select_tag 's[page_side_eq]', options_for_select(resource_class.page_side_choices, @search.s[:page_side_eq]), include_blank: true, class: 'form-control'
           hr
 

--- a/app/views/shared/_grid_filters.html.slim
+++ b/app/views/shared/_grid_filters.html.slim
@@ -70,7 +70,7 @@
                 input.form-control#s_enum_dist_eq type="search" name="s[enum_dist_eq]" value=@search.s[:enum_dist_eq]
             .col-3
               label for="s_page_number_eq"= translated_label(resource_class, :page_number)
-              = select_tag 's[page_number_eq]', options_for_select(@search.sheet_number_options, @search.s[:page_number_eq]), include_blank: true, class: 'form-control'
+              input.form-control#s_page_number_eq type="number" name="s[page_number_eq]" value=@search.s[:page_number_eq] min="1" max=CensusRecordSearch::PAGE_NUMBER_MAX
             - if controller.year < 1950 and controller.year >= 1880
               .col-3
                 label for="s_page_side_eq"= translated_label(resource_class, :page_side)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,7 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET transaction_timeout = 0;
+-- SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);

--- a/spec/services/census_record_search_spec.rb
+++ b/spec/services/census_record_search_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CensusRecordSearch do
+  describe '#sheet_number_options' do
+    let(:locality) { create(:locality) }
+    let(:user) { create(:active_user) }
+
+    before do
+      Current.locality_id = locality.id
+      create(:census1870_record,
+             locality:,
+             page_number: 250,
+             line_number: 1,
+             post_office: 'Ithaca',
+             city: 'Ithaca',
+             county: 'Tompkins',
+             state: 'New York',
+             first_name: 'John',
+             last_name: 'Doe',
+             family_id: '1',
+             occupation: 'None')
+    end
+
+    after { Current.reset }
+
+    it 'includes sheet numbers beyond the old 200 limit' do
+      search = described_class.generate(year: 1870, params: { s: { page_number_eq: '250' } }, user:)
+      expect(search.sheet_number_options).to include(250)
+      expect(search.sheet_number_options.last).to eq(250)
+    end
+
+    it 'includes the selected sheet even when it exceeds the database maximum' do
+      search = described_class.generate(year: 1870, params: { s: { page_number_eq: '300' } }, user:)
+      expect(search.sheet_number_options).to include(300)
+    end
+
+    it 'defaults to at least 200 when no records exist' do
+      Census1870Record.delete_all
+      search = described_class.generate(year: 1870, params: {}, user:)
+      expect(search.sheet_number_options).to eq((1..200).to_a)
+    end
+  end
+end

--- a/spec/services/census_record_search_spec.rb
+++ b/spec/services/census_record_search_spec.rb
@@ -3,43 +3,68 @@
 require 'rails_helper'
 
 RSpec.describe CensusRecordSearch do
-  describe '#sheet_number_options' do
-    let(:locality) { create(:locality) }
-    let(:user) { create(:active_user) }
+  let(:locality) { create(:locality) }
+  let(:user) { create(:active_user) }
 
+  def build_search(params = {})
+    described_class.generate(year: 1870, params:, user:)
+  end
+
+  def create_1870_record(page_number:)
+    create(:census1870_record,
+           locality:,
+           page_number:,
+           line_number: 1,
+           post_office: 'Ithaca',
+           city: 'Ithaca',
+           county: 'Tompkins',
+           state: 'New York',
+           first_name: 'John',
+           last_name: 'Doe',
+           family_id: '1',
+           occupation: 'None')
+  end
+
+  describe '#max_page_number' do
     before do
       Current.locality_id = locality.id
-      create(:census1870_record,
-             locality:,
-             page_number: 250,
-             line_number: 1,
-             post_office: 'Ithaca',
-             city: 'Ithaca',
-             county: 'Tompkins',
-             state: 'New York',
-             first_name: 'John',
-             last_name: 'Doe',
-             family_id: '1',
-             occupation: 'None')
+      create_1870_record(page_number: 250)
     end
 
     after { Current.reset }
 
-    it 'includes sheet numbers beyond the old 200 limit' do
-      search = described_class.generate(year: 1870, params: { s: { page_number_eq: '250' } }, user:)
-      expect(search.sheet_number_options).to include(250)
-      expect(search.sheet_number_options.last).to eq(250)
+    it 'reflects the highest page number in the database' do
+      expect(build_search.s[:page_number_eq]).to be_nil
+      expect(build_search.max_page_number).to eq(250)
     end
 
-    it 'includes the selected sheet even when it exceeds the database maximum' do
-      search = described_class.generate(year: 1870, params: { s: { page_number_eq: '300' } }, user:)
-      expect(search.sheet_number_options).to include(300)
+    it 'includes the selected page when it exceeds the database maximum' do
+      expect(build_search(s: { page_number_eq: '300' }).max_page_number).to eq(300)
     end
 
-    it 'defaults to at least 200 when no records exist' do
+    it 'returns zero when no records exist' do
       Census1870Record.delete_all
-      search = described_class.generate(year: 1870, params: {}, user:)
-      expect(search.sheet_number_options).to eq((1..200).to_a)
+      expect(build_search.max_page_number).to eq(0)
+    end
+  end
+
+  describe 'page number filter normalization' do
+    before { Current.locality_id = locality.id }
+    after { Current.reset }
+
+    it 'preserves valid page numbers' do
+      search = build_search(s: { page_number_eq: '250' })
+      expect(search.s[:page_number_eq]).to eq('250')
+    end
+
+    it 'clamps page numbers above the maximum' do
+      search = build_search(s: { page_number_eq: '99999' })
+      expect(search.s[:page_number_eq]).to eq('10000')
+    end
+
+    it 'drops invalid page numbers' do
+      search = build_search(s: { page_number_eq: 'abc' })
+      expect(search.s[:page_number_eq]).to be_nil
     end
   end
 end


### PR DESCRIPTION
It's hard to review the 1870 census because there are only page numbers, and it's limited at 200. The reason is that it is traditionally divided into enumeration districts. That wasn't the case in 1870.

The fix is to make it check how many sheets there are before offering a number input (rather than a select list).

Also saw that the filter says "Sheet" but the chip says "Page equals 200". So this PR also equalizes on the "translated label" of "Page".