### PR TITLE
#516 session auth redirect stuff

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,11 +87,14 @@ class ApplicationController < ActionController::Base
   end
 
   def permission_denied
-    flash[:error] = if user_signed_in?
+    signed_in = user_signed_in?
+    flash[:error] = if signed_in
                       'Sorry you do not have permission to do that.'
                     else
                       'Your session may have expired. Please sign in again.'
                     end
+    # Force a full page reload so the permanent header reflects logged-out state
+    response.headers['Turbo-Visit-Control'] = 'reload' unless signed_in
     redirect_to root_path
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -145,6 +145,23 @@ document.addEventListener('DOMContentLoaded', initializePage)
 document.addEventListener('turbo:load', initializePage)
 document.addEventListener('turbo:before-cache', cleanupPage)
 
+// The header is data-turbo-permanent, so it can show a logged-in menu after the session
+// expires. Compare the server-rendered auth state on each page to the header and reload
+// when they disagree.
+function syncAuthStateWithHeader() {
+  const authMeta = document.querySelector('meta[name="hf-auth"]')
+  if (!authMeta) return
+
+  const serverSignedIn = authMeta.content === 'signed-in'
+  const headerShowsSignedIn = document.querySelector('#main-header #user-menu-item') !== null
+
+  if (serverSignedIn !== headerShowsSignedIn) {
+    window.location.reload()
+  }
+}
+
+document.addEventListener('turbo:load', syncAuthStateWithHeader)
+
 // Update header data (flag counts, login status) - called after login/logout or flag updates
 // Update header from incoming Turbo response to avoid flashing
 // Since header is permanent (data-turbo-permanent), Turbo won't replace it automatically

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,6 +7,7 @@ html
     / Prevent Turbo from caching pages when logged in - avoids stale auth state and "permission denied" after session expiry
     - if user_signed_in?
       meta name="turbo-cache-control" content="no-cache"
+    meta name="hf-auth" content=(user_signed_in? ? 'signed-in' : 'signed-out')
     link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"
     link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"
     link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_hf_session'
+Rails.application.config.session_store :cookie_store, key: '_hf_session', expire_after: 2.weeks


### PR DESCRIPTION
Power users sometimes get logged out abruptly.

This matches a known issue tracked as [#518](https://github.com/historyforge/historyforge/pull/518) — abrupt logout — that started after the Turbo migration in early January. Your Mar 1 incident was a week before that partial fix shipped on Mar 9.

What you're experiencing
This is almost certainly not a real permissions problem. The sequence is:

You're working on a census record (Percy Brown via "On the same street" from Doris Colgrove's record).
Your session expires in the background while you're on the form.
You click Save → the server rejects the request because you're no longer authenticated.
The nav bar still shows you as logged in because it uses data-turbo-permanent — Turbo keeps the old header across page visits instead of replacing it.
Only a full browser refresh reveals you're actually logged out.
The confusing error message made this worse. Before #518, every auth failure showed "Sorry you do not have permission to do that." — even session expiry. #518 added a distinct message ("Your session may have expired…") and prevented Turbo from caching pages while logged in, but the stale header problem could still leave you looking logged in after a failed save.

Why it started ~a month ago
The "make forms more turbo compliant" work (early January) moved form submissions to Turbo Drive navigation. That works well, but combined with the permanent header it means auth state in the UI can fall out of sync with the server when a session expires mid-task — especially on long census transcription sessions.

What I've added
Three changes on your 516-abrupt-logouts branch:

Session cookies now last 2 weeks (expire_after: 2.weeks) — reduces mid-session dropoffs during long transcription work.
Turbo-Visit-Control: reload on session-expiry redirects — when a save fails because you're logged out, Turbo does a full page reload instead of a partial visit, so the header updates correctly.
Auth-state sync check — each page now carries a hf-auth meta tag; if the header disagrees with the server (logged-in menu vs. signed-out page), the browser auto-reloads.